### PR TITLE
Make CharCounter's background fit better to chat

### DIFF
--- a/CharCounter/build.gradle.kts
+++ b/CharCounter/build.gradle.kts
@@ -1,22 +1,25 @@
-version = "1.4.0"
+version = "1.4.1"
 description = "Adds a character counter to the message box"
 
 aliucord.changelog.set("""
+    # 1.4.1
+    * Improved the background to fit in with chat
+
     # 1.4.0
     * Added threshold option
     * Added reverse option
     * Added color to show when too many characters are entered
-   
+
     # 1.2.2
     * Fixed issue with background
     * Added an option to always show the counter even when theres no input text
 
     # 1.2.1
     * Improved appearance
-    
+
     # 1.2.0
     * Counter is now properly placed in the bar
-        
+
     # 1.1.0
     * Support V96
 """.trimIndent())

--- a/CharCounter/src/main/java/com/aliucord/plugins/CharCounter.kt
+++ b/CharCounter/src/main/java/com/aliucord/plugins/CharCounter.kt
@@ -62,7 +62,7 @@ class CharCounter : Plugin() {
                 }
                 8.dp.let { dp -> setPadding(dp, 0, dp, 0) }
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, root.resources.getDimension(textSizeDimenId))
-                setBackgroundColor(ColorCompat.getThemedColor(root.context, R.b.primary_630))
+                setBackgroundColor(ColorCompat.getThemedColor(root.context, R.c.primary_dark_600))
                 root.addView(this)
             }
 


### PR DESCRIPTION
The old color always used to look off. This makes CharCounter use the same color as e.g. chat message backgrounds.

With this change the counter looks like this:

![Regular Dark theme preview](https://user-images.githubusercontent.com/40118124/187050647-f49f601f-d7ea-442e-8eed-0b81d8b0c585.png)

![image](https://user-images.githubusercontent.com/40118124/187050665-fecb738a-ba52-4a8e-b898-1d7b0294c891.png)

And here even a custom theme:

![image](https://user-images.githubusercontent.com/40118124/187050670-0389e59d-e950-405d-8044-53be3237f448.png)


And currently, without the patch, it's looking like this, looking a bit off with that different background color and sharp corners:

![image](https://user-images.githubusercontent.com/40118124/187050683-0eac724c-3583-4533-a475-abdc44bcc320.png)
