### PR TITLE
Add error safety to Frecents.kt line 106-109 to skip null elements

### DIFF
--- a/plugin/Frecents/src/main/kotlin/dev/zt64/aliucord/plugins/Frecents.kt
+++ b/plugin/Frecents/src/main/kotlin/dev/zt64/aliucord/plugins/Frecents.kt
@@ -101,12 +101,14 @@ class Frecents : Plugin() {
 
             frecencySettings.observeSettings().switchMap { frecents ->
                 ScalarSynchronousObservable(
-                    frecents.favoriteEmojis.emojisList.map {
+                    frecents.favoriteEmojis.emojisList.mapNotNull {
                         if (pattern.matcher(it).matches()) {
                             Favorite.FavCustomEmoji(it)
                         } else {
                             @Suppress("USELESS_CAST") // IDE doesn't like without this cast
-                            Favorite.FavUnicodeEmoji(emojiStore.unicodeEmojisNamesMap[it]!!.uniqueId) as Favorite
+                            emojiStore.unicodeEmojisNamesMap[it]?.let { emoji ->
+                                Favorite.FavUnicodeEmoji(emoji.uniqueId) as Favorite
+                            }
                         }
                     }.toSet()
                 )


### PR DESCRIPTION
The emoji favorites observer crashes when `unicodeEmojisNamesMap` lookup returns null for emoji identifiers not found in the store.

**Changes:**
- Replace `.map` with `.mapNotNull` to filter out failed lookups
- Replace force unwrap (`!!`) with safe call (`?.let`) when accessing emoji from map

**Before:**
```kotlin
frecents.favoriteEmojis.emojisList.map {
    if (pattern.matcher(it).matches()) {
        Favorite.FavCustomEmoji(it)
    } else {
        Favorite.FavUnicodeEmoji(emojiStore.unicodeEmojisNamesMap[it]!!.uniqueId) as Favorite
    }
}.toSet()
```

**After:**
```kotlin
frecents.favoriteEmojis.emojisList.mapNotNull {
    if (pattern.matcher(it).matches()) {
        Favorite.FavCustomEmoji(it)
    } else {
        emojiStore.unicodeEmojisNamesMap[it]?.let { emoji ->
            Favorite.FavUnicodeEmoji(emoji.uniqueId) as Favorite
        }
    }
}.toSet()
```

Elements with null lookups are now skipped rather than causing NPE.

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `dl.google.com`
> - `jitpack.io`
>   - Triggering command: `/usr/lib/jvm/temurin-17-jdk-amd64/bin/java --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED -Xmx2048m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant -cp /home/REDACTED/.gradle/wrapper/dists/gradle-7.6.2-bin/6ot4hgy1mty27tup86cmng5lx/gradle-7.6.2/lib/gradle-launcher-7.6.2.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 7.6.2` (dns block)
> - `maven.aliucord.com`
>   - Triggering command: `/usr/lib/jvm/temurin-17-jdk-amd64/bin/java --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED -Xmx2048m -Dfile.encoding=UTF-8 -Duser.country -Duser.language=en -Duser.variant -cp /home/REDACTED/.gradle/wrapper/dists/gradle-7.6.2-bin/6ot4hgy1mty27tup86cmng5lx/gradle-7.6.2/lib/gradle-launcher-7.6.2.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 7.6.2` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/Aliucoin/aliucord-plugins-1/settings/copilot/coding_agent) (admins only)
>
> </details>

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> Add error safety to line 106 of aliucord-plugins-1/plugin/Frecents/src/main/kotlin/dev/zt64/aliucord/plugins
> /Frecents.kt. just skip elements if there is a null case


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.