### PR TITLE
fix(CompactMode): hide avatar decos more consistently

### DIFF
--- a/plugin/CompactMode/src/main/kotlin/CompactMode.kt
+++ b/plugin/CompactMode/src/main/kotlin/CompactMode.kt
@@ -153,7 +153,10 @@ class CompactMode : Plugin() {
                     }
                     if (settings.hideAvatar) {
                         avatarView!!.visibility = View.GONE
-                        avatarDecoration?.visibility = View.GONE
+                        avatarDecoration?.layoutParams<ConstraintLayout.LayoutParams>()?.run {
+                            height = 0
+                            width = 0
+                        }
 
                         headerView.layoutParams<ConstraintLayout.LayoutParams>().marginStart = contentMargin
 


### PR DESCRIPTION
Patch order is kinda random so sometimes the Decoration coreplugin would reset it to back to visible after CompactMode has hidden it.

This just sets the width and height to 0 which effectively hides it and won't be reset, since the coreplugin doesn't mess with it during configuration.